### PR TITLE
Initial module

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,20 @@ module "rancher_install" {
 }
 ```
 
+#### Air-gap environment (without auth)
+
+```hcl
+module "rancher_install" {
+  source = "github.com/terraform-rancher-modules/terraform-rancher-install"
+
+  rancher_hostname = "rancher.example.com"
+
+  airgap = true
+  default_registry = "registry.example.com:5000"
+  helm_repository = "https://helm.example.com/rancher-charts/"
+}
+```
+
 ## Requirements
 
 | Name | Version |

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ module "rancher_install" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.3.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.4.1 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.6.1 |
 
 ## Modules
@@ -90,6 +90,7 @@ No modules.
 |------|------|
 | [helm_release.cert_manager](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.rancher](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [kubernetes_secret.image_pull_secret](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.tls_ca](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.tls_rancher_ingress](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 
@@ -97,19 +98,26 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_cacerts_path"></a> [cacerts\_path](#input\_cacerts\_path) | Private CA certificate to use for Rancher UI/API connectivity | `any` | `null` | no |
-| <a name="input_cert_manager_enable"></a> [cert\_manager\_enable](#input\_cert\_manager\_enable) | Install cert-manager even if not needed for Rancher, useful if migrating to certificates | `bool` | `false` | no |
+| <a name="input_airgap"></a> [airgap](#input\_airgap) | Enable airgap options for the Rancher environment, requires default\_registry to be set | `bool` | `false` | no |
+| <a name="input_cacerts_path"></a> [cacerts\_path](#input\_cacerts\_path) | Private CA certificate to use for Rancher UI/API connectivity | `string` | `null` | no |
+| <a name="input_cert_manager_enable"></a> [cert\_manager\_enable](#input\_cert\_manager\_enable) | Install cert-manager even if not needed for Rancher, useful if migrating to certificates | `string` | `false` | no |
 | <a name="input_cert_manager_namespace"></a> [cert\_manager\_namespace](#input\_cert\_manager\_namespace) | Namesapce to install cert-manager | `string` | `"cert-manager"` | no |
 | <a name="input_cert_manager_version"></a> [cert\_manager\_version](#input\_cert\_manager\_version) | Version of cert-manager to install | `string` | `"v1.5.1"` | no |
+| <a name="input_default_registry"></a> [default\_registry](#input\_default\_registry) | Default container image registry to pull images in the format of registry.domain.com:port (systemDefaultRegistry helm value) | `string` | `null` | no |
+| <a name="input_helm_password"></a> [helm\_password](#input\_helm\_password) | Private helm repository password | `string` | `null` | no |
+| <a name="input_helm_repository"></a> [helm\_repository](#input\_helm\_repository) | Helm repository for Rancher and cert-manager charts | `string` | `null` | no |
+| <a name="input_helm_username"></a> [helm\_username](#input\_helm\_username) | Private helm repository username | `string` | `null` | no |
 | <a name="input_kubeconfig_file"></a> [kubeconfig\_file](#input\_kubeconfig\_file) | The kubeconfig to use to interact with the cluster | `string` | `"~/.kube/config"` | no |
 | <a name="input_rancher_additional_helm_values"></a> [rancher\_additional\_helm\_values](#input\_rancher\_additional\_helm\_values) | Helm options to provide to the Rancher helm chart | `list(string)` | `[]` | no |
 | <a name="input_rancher_antiaffinity"></a> [rancher\_antiaffinity](#input\_rancher\_antiaffinity) | Value for antiAffinity when installing the Rancher helm chart (required/preferred) | `string` | `"required"` | no |
 | <a name="input_rancher_bootstrap_password"></a> [rancher\_bootstrap\_password](#input\_rancher\_bootstrap\_password) | Password to use for bootstrapping Rancher | `string` | `"admin"` | no |
-| <a name="input_rancher_hostname"></a> [rancher\_hostname](#input\_rancher\_hostname) | Value for hostname when installing the Rancher helm chart | `any` | n/a | yes |
+| <a name="input_rancher_hostname"></a> [rancher\_hostname](#input\_rancher\_hostname) | Value for hostname when installing the Rancher helm chart | `string` | n/a | yes |
 | <a name="input_rancher_replicas"></a> [rancher\_replicas](#input\_rancher\_replicas) | Value for replicas when installing the Rancher helm chart | `number` | `3` | no |
-| <a name="input_rancher_version"></a> [rancher\_version](#input\_rancher\_version) | Rancher version to install | `any` | `null` | no |
-| <a name="input_tls_crt_path"></a> [tls\_crt\_path](#input\_tls\_crt\_path) | TLS certificate to use for Rancher UI/API connectivity | `any` | `null` | no |
-| <a name="input_tls_key_path"></a> [tls\_key\_path](#input\_tls\_key\_path) | TLS key to use for Rancher UI/API connectivity | `any` | `null` | no |
+| <a name="input_rancher_version"></a> [rancher\_version](#input\_rancher\_version) | Rancher version to install | `string` | `null` | no |
+| <a name="input_registry_password"></a> [registry\_password](#input\_registry\_password) | Private container image registry password | `string` | `null` | no |
+| <a name="input_registry_username"></a> [registry\_username](#input\_registry\_username) | Private container image registry username | `string` | `null` | no |
+| <a name="input_tls_crt_path"></a> [tls\_crt\_path](#input\_tls\_crt\_path) | TLS certificate to use for Rancher UI/API connectivity | `string` | `null` | no |
+| <a name="input_tls_key_path"></a> [tls\_key\_path](#input\_tls\_key\_path) | TLS key to use for Rancher UI/API connectivity | `string` | `null` | no |
 | <a name="input_tls_source"></a> [tls\_source](#input\_tls\_source) | Value for ingress.tls.source when installing the Rancher helm chart | `string` | `"rancher"` | no |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -1,1 +1,120 @@
-# terraform-rancher-install
+# Terraform | Rancher Install
+
+Terraform module to install Rancher using helm to complete an HA installation.
+
+### Usage
+
+```hcl
+module "rancher_install" {
+  source = "github.com/terraform-rancher-modules/terraform-rancher-install"
+
+  rancher_hostname = "rancher.example.com"
+}
+```
+
+## Examples
+
+#### Private CA and certificates
+
+```hcl
+module "rancher_install" {
+  source = "github.com/terraform-rancher-modules/terraform-rancher-install"
+
+  rancher_hostname = "rancher.example.com"
+
+  tls_source   = "secret"
+  cacerts_path = "certs/ca.pem"
+  tls_crt_path = "certs/cert.pem"
+  tls_key_path = "certs/key.pem"
+}
+```
+
+#### Custom kubeconfig location
+
+```hcl
+module "rancher_install" {
+  source = "github.com/terraform-rancher-modules/terraform-rancher-install"
+
+  rancher_hostname = "rancher.example.com"
+  kubeconfig_file  = "/path/to/kubeconfig"
+}
+```
+
+#### Single replica for Rancher, and pin the version
+
+```hcl
+module "rancher_install" {
+  source = "github.com/terraform-rancher-modules/terraform-rancher-install"
+
+  rancher_hostname = "rancher.example.com"
+  rancher_replicas  = 1
+  rancher_version   = "2.6.2"
+}
+```
+
+#### Additional values for the Rancher chart
+
+```hcl
+module "rancher_install" {
+  source = "github.com/terraform-rancher-modules/terraform-rancher-install"
+
+  rancher_hostname = "rancher.example.com"
+  rancher_additional_helm_values = [
+    "bootstrapPassword: secret-string",
+    "auditLog.level: 1"
+  ]
+}
+```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.4.1 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.6.1 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.3.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.6.1 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [helm_release.cert_manager](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [helm_release.rancher](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [kubernetes_secret.tls_ca](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+| [kubernetes_secret.tls_rancher_ingress](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cacerts_path"></a> [cacerts\_path](#input\_cacerts\_path) | Private CA certificate to use for Rancher UI/API connectivity | `any` | `null` | no |
+| <a name="input_cert_manager_enable"></a> [cert\_manager\_enable](#input\_cert\_manager\_enable) | Install cert-manager even if not needed for Rancher, useful if migrating to certificates | `bool` | `false` | no |
+| <a name="input_cert_manager_namespace"></a> [cert\_manager\_namespace](#input\_cert\_manager\_namespace) | Namesapce to install cert-manager | `string` | `"cert-manager"` | no |
+| <a name="input_cert_manager_version"></a> [cert\_manager\_version](#input\_cert\_manager\_version) | Version of cert-manager to install | `string` | `"v1.5.1"` | no |
+| <a name="input_kubeconfig_file"></a> [kubeconfig\_file](#input\_kubeconfig\_file) | The kubeconfig to use to interact with the cluster | `string` | `"~/.kube/config"` | no |
+| <a name="input_rancher_additional_helm_values"></a> [rancher\_additional\_helm\_values](#input\_rancher\_additional\_helm\_values) | Helm options to provide to the Rancher helm chart | `list(string)` | `[]` | no |
+| <a name="input_rancher_antiaffinity"></a> [rancher\_antiaffinity](#input\_rancher\_antiaffinity) | Value for antiAffinity when installing the Rancher helm chart (required/preferred) | `string` | `"required"` | no |
+| <a name="input_rancher_bootstrap_password"></a> [rancher\_bootstrap\_password](#input\_rancher\_bootstrap\_password) | Password to use for bootstrapping Rancher | `string` | `"admin"` | no |
+| <a name="input_rancher_hostname"></a> [rancher\_hostname](#input\_rancher\_hostname) | Value for hostname when installing the Rancher helm chart | `any` | n/a | yes |
+| <a name="input_rancher_replicas"></a> [rancher\_replicas](#input\_rancher\_replicas) | Value for replicas when installing the Rancher helm chart | `number` | `3` | no |
+| <a name="input_rancher_version"></a> [rancher\_version](#input\_rancher\_version) | Rancher version to install | `any` | `null` | no |
+| <a name="input_tls_crt_path"></a> [tls\_crt\_path](#input\_tls\_crt\_path) | TLS certificate to use for Rancher UI/API connectivity | `any` | `null` | no |
+| <a name="input_tls_key_path"></a> [tls\_key\_path](#input\_tls\_key\_path) | TLS key to use for Rancher UI/API connectivity | `any` | `null` | no |
+| <a name="input_tls_source"></a> [tls\_source](#input\_tls\_source) | Value for ingress.tls.source when installing the Rancher helm chart | `string` | `"rancher"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_rancher_bootstrap_password"></a> [rancher\_bootstrap\_password](#output\_rancher\_bootstrap\_password) | Password to use for bootstrapping Rancher |
+| <a name="output_rancher_hostname"></a> [rancher\_hostname](#output\_rancher\_hostname) | Value for hostname when installing the Rancher helm chart |

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,77 @@
+locals {
+  rancher_default_helm_values = [
+    "antiAffinity: ${var.rancher_antiaffinity}",
+    "ingress.tls.source: ${var.tls_source}",
+    "hostname: ${var.rancher_hostname}",
+    "bootstrapPassword: ${var.rancher_bootstrap_password}",
+    "replicas: ${var.rancher_replicas}"
+  ]
+  rancher_helm_values = distinct(flatten([var.rancher_additional_helm_values, local.rancher_default_helm_values]))
+}
+
+resource "kubernetes_secret" "tls_rancher_ingress" {
+  count = var.tls_source == "secret" ? 1 : 0
+  metadata {
+    name      = "tls-rancher-ingress"
+    namespace = helm_release.rancher.namespace
+  }
+  data = {
+    "tls.crt" = file(var.tls_crt_path)
+    "tls.key" = file(var.tls_key_path)
+  }
+  type = "kubernetes.io/tls"
+
+  lifecycle {
+    ignore_changes = [metadata]
+  }
+}
+
+resource "kubernetes_secret" "tls_ca" {
+  count = var.tls_source == "secret" ? 1 : 0
+  metadata {
+    name      = "tls-ca"
+    namespace = helm_release.rancher.namespace
+  }
+  data = {
+    "cacerts.pem" = file(var.cacerts_path)
+  }
+
+  lifecycle {
+    ignore_changes = [metadata]
+  }
+}
+
+resource "helm_release" "cert_manager" {
+  count            = var.tls_source == "rancher" || var.tls_source == "letsEncrypt" || var.cert_manager_enable ? 1 : 0
+  name             = "cert-manager"
+  repository       = "https://charts.jetstack.io"
+  chart            = "cert-manager"
+  namespace        = var.cert_manager_namespace
+  version          = var.cert_manager_version
+  wait             = true
+  create_namespace = true
+
+  set {
+    name  = "installCRDs"
+    value = "true"
+  }
+}
+
+resource "helm_release" "rancher" {
+  depends_on       = [helm_release.cert_manager]
+  name             = "rancher"
+  repository       = "https://releases.rancher.com/server-charts/stable"
+  chart            = "rancher"
+  namespace        = "cattle-system"
+  version          = var.rancher_version
+  wait             = true
+  create_namespace = true
+
+  dynamic "set" {
+    for_each = local.rancher_helm_values
+    content {
+      name  = split(":", set.value)[0]
+      value = trimprefix(split(":", set.value)[1], " ")
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -55,7 +55,7 @@ resource "kubernetes_secret" "tls_ca" {
 }
 
 resource "kubernetes_secret" "image_pull_secret" {
-  count      = var.registry_username != null ? 1 : 0
+  count = var.registry_username != null ? 1 : 0
   metadata {
     name      = "rancher-pull-secret"
     namespace = helm_release.rancher.namespace
@@ -87,6 +87,7 @@ resource "helm_release" "cert_manager" {
   set {
     name  = "installCRDs"
     value = "true"
+    type  = "string"
   }
 }
 
@@ -107,6 +108,7 @@ resource "helm_release" "rancher" {
     content {
       name  = split(":", set.value)[0]
       value = trimprefix(split(":", set.value)[1], " ")
+      type  = trimprefix(split(":", set.value)[1], " ") == "true" || trimprefix(split(":", set.value)[1], " ") == "false" ? "string" : null
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -53,7 +53,6 @@ resource "kubernetes_secret" "tls_ca" {
 
 resource "kubernetes_secret" "image_pull_secret" {
   count      = var.registry_username != null ? 1 : 0
-  depends_on = [helm_release.rancher]
   metadata {
     name      = "rancher-pull-secret"
     namespace = helm_release.rancher.namespace

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,15 @@ locals {
     "bootstrapPassword: ${var.rancher_bootstrap_password}",
     "replicas: ${var.rancher_replicas}"
   ]
-  rancher_helm_values = distinct(flatten([var.rancher_additional_helm_values, local.rancher_default_helm_values]))
+  rancher_airgap_helm_values = var.airgap ? [
+    "rancherImage: ${var.default_registry}/rancher/rancher",
+    "systemDefaultRegistry: ${var.default_registry}",
+    "useBundledSystemChart: true"
+  ] : []
+  rancher_registry_pull_secret = var.registry_username != null ? [
+    "imagePullSecrets[0].name: rancher-pull-secret"
+  ] : []
+  rancher_helm_values = distinct(flatten([local.rancher_airgap_helm_values, local.rancher_registry_pull_secret, var.rancher_additional_helm_values, local.rancher_default_helm_values]))
 }
 
 resource "kubernetes_secret" "tls_rancher_ingress" {
@@ -15,6 +23,7 @@ resource "kubernetes_secret" "tls_rancher_ingress" {
     name      = "tls-rancher-ingress"
     namespace = helm_release.rancher.namespace
   }
+
   data = {
     "tls.crt" = file(var.tls_crt_path)
     "tls.key" = file(var.tls_key_path)
@@ -32,6 +41,7 @@ resource "kubernetes_secret" "tls_ca" {
     name      = "tls-ca"
     namespace = helm_release.rancher.namespace
   }
+
   data = {
     "cacerts.pem" = file(var.cacerts_path)
   }
@@ -41,15 +51,36 @@ resource "kubernetes_secret" "tls_ca" {
   }
 }
 
+resource "kubernetes_secret" "image_pull_secret" {
+  count      = var.registry_username != null ? 1 : 0
+  depends_on = [helm_release.rancher]
+  metadata {
+    name      = "rancher-pull-secret"
+    namespace = helm_release.rancher.namespace
+  }
+
+  type = "Opaque"
+  data = {
+    "username" = var.registry_username
+    "password" = var.registry_password
+  }
+
+  lifecycle {
+    ignore_changes = [metadata]
+  }
+}
+
 resource "helm_release" "cert_manager" {
-  count            = var.tls_source == "rancher" || var.tls_source == "letsEncrypt" || var.cert_manager_enable ? 1 : 0
-  name             = "cert-manager"
-  repository       = "https://charts.jetstack.io"
-  chart            = "cert-manager"
-  namespace        = var.cert_manager_namespace
-  version          = var.cert_manager_version
-  wait             = true
-  create_namespace = true
+  count               = var.tls_source == "rancher" || var.tls_source == "letsEncrypt" || var.cert_manager_enable ? 1 : 0
+  name                = "cert-manager"
+  repository          = var.helm_repository != null ? var.helm_repository : "https://charts.jetstack.io"
+  chart               = "cert-manager"
+  namespace           = var.cert_manager_namespace
+  version             = var.cert_manager_version
+  repository_username = var.helm_username != null ? var.helm_username : null
+  repository_password = var.helm_password != null ? var.helm_password : null
+  wait                = true
+  create_namespace    = true
 
   set {
     name  = "installCRDs"
@@ -58,14 +89,16 @@ resource "helm_release" "cert_manager" {
 }
 
 resource "helm_release" "rancher" {
-  depends_on       = [helm_release.cert_manager]
-  name             = "rancher"
-  repository       = "https://releases.rancher.com/server-charts/stable"
-  chart            = "rancher"
-  namespace        = "cattle-system"
-  version          = var.rancher_version
-  wait             = true
-  create_namespace = true
+  depends_on          = [helm_release.cert_manager]
+  name                = "rancher"
+  repository          = var.helm_repository != null ? var.helm_repository : "https://releases.rancher.com/server-charts/stable"
+  chart               = "rancher"
+  namespace           = "cattle-system"
+  version             = var.rancher_version
+  repository_username = var.helm_username != null ? var.helm_username : null
+  repository_password = var.helm_password != null ? var.helm_password : null
+  wait                = true
+  create_namespace    = true
 
   dynamic "set" {
     for_each = local.rancher_helm_values

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,10 @@
+output "rancher_hostname" {
+  description = "Value for hostname when installing the Rancher helm chart"
+  value       = var.rancher_hostname
+}
+
+output "rancher_bootstrap_password" {
+  description = "Password to use for bootstrapping Rancher"
+  value       = var.rancher_bootstrap_password
+  sensitive   = true
+}

--- a/provider.tf
+++ b/provider.tf
@@ -1,0 +1,10 @@
+provider "helm" {
+  kubernetes {
+    config_path = var.kubeconfig_file
+  }
+}
+
+provider "kubernetes" {
+  config_path = var.kubeconfig_file
+  insecure    = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,69 @@
+variable "kubeconfig_file" {
+  description = "The kubeconfig to use to interact with the cluster"
+  default     = "~/.kube/config"
+}
+
+variable "cert_manager_namespace" {
+  description = "Namesapce to install cert-manager"
+  default     = "cert-manager"
+}
+
+variable "cert_manager_version" {
+  description = "Version of cert-manager to install"
+  default     = "v1.5.1"
+}
+
+variable "cert_manager_enable" {
+  description = "Install cert-manager even if not needed for Rancher, useful if migrating to certificates"
+  default     = false
+}
+
+variable "rancher_additional_helm_values" {
+  description = "Helm options to provide to the Rancher helm chart"
+  default     = []
+  type        = list(string)
+}
+
+variable "rancher_antiaffinity" {
+  description = "Value for antiAffinity when installing the Rancher helm chart (required/preferred)"
+  default     = "required"
+}
+
+variable "rancher_bootstrap_password" {
+  description = "Password to use for bootstrapping Rancher"
+  default     = "admin"
+}
+
+variable "rancher_hostname" {
+  description = "Value for hostname when installing the Rancher helm chart"
+}
+
+variable "rancher_replicas" {
+  description = "Value for replicas when installing the Rancher helm chart"
+  default     = 3
+}
+
+variable "rancher_version" {
+  description = "Rancher version to install"
+  default     = null
+}
+
+variable "cacerts_path" {
+  default     = null
+  description = "Private CA certificate to use for Rancher UI/API connectivity"
+}
+
+variable "tls_crt_path" {
+  description = "TLS certificate to use for Rancher UI/API connectivity"
+  default     = null
+}
+
+variable "tls_key_path" {
+  description = "TLS key to use for Rancher UI/API connectivity"
+  default     = null
+}
+
+variable "tls_source" {
+  description = "Value for ingress.tls.source when installing the Rancher helm chart"
+  default     = "rancher"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,23 +1,43 @@
 variable "kubeconfig_file" {
   description = "The kubeconfig to use to interact with the cluster"
   default     = "~/.kube/config"
+  type        = string
 }
 
+variable "airgap" {
+  description = "Enable airgap options for the Rancher environment, requires default_registry to be set"
+  default     = false
+  type        = bool
+}
 variable "cert_manager_namespace" {
   description = "Namesapce to install cert-manager"
   default     = "cert-manager"
+  type        = string
 }
 
 variable "cert_manager_version" {
   description = "Version of cert-manager to install"
   default     = "v1.5.1"
+  type        = string
 }
 
 variable "cert_manager_enable" {
   description = "Install cert-manager even if not needed for Rancher, useful if migrating to certificates"
   default     = false
+  type        = string
 }
 
+variable "default_registry" {
+  description = "Default container image registry to pull images in the format of registry.domain.com:port (systemDefaultRegistry helm value)"
+  default     = null
+  type        = string
+}
+
+variable "helm_repository" {
+  description = "Helm repository for Rancher and cert-manager charts"
+  default     = null
+  type        = string
+}
 variable "rancher_additional_helm_values" {
   description = "Helm options to provide to the Rancher helm chart"
   default     = []
@@ -27,43 +47,76 @@ variable "rancher_additional_helm_values" {
 variable "rancher_antiaffinity" {
   description = "Value for antiAffinity when installing the Rancher helm chart (required/preferred)"
   default     = "required"
+  type        = string
 }
 
 variable "rancher_bootstrap_password" {
   description = "Password to use for bootstrapping Rancher"
   default     = "admin"
+  type        = string
 }
 
 variable "rancher_hostname" {
   description = "Value for hostname when installing the Rancher helm chart"
+  type        = string
 }
 
 variable "rancher_replicas" {
   description = "Value for replicas when installing the Rancher helm chart"
   default     = 3
+  type        = number
 }
 
 variable "rancher_version" {
   description = "Rancher version to install"
   default     = null
+  type        = string
+}
+
+variable "helm_username" {
+  description = "Private helm repository username"
+  default     = null
+  type        = string
+}
+
+variable "helm_password" {
+  description = "Private helm repository password"
+  default     = null
+  type        = string
+}
+
+variable "registry_username" {
+  description = "Private container image registry username"
+  default     = null
+  type        = string
+}
+
+variable "registry_password" {
+  description = "Private container image registry password"
+  default     = null
+  type        = string
 }
 
 variable "cacerts_path" {
   default     = null
   description = "Private CA certificate to use for Rancher UI/API connectivity"
+  type        = string
 }
 
 variable "tls_crt_path" {
   description = "TLS certificate to use for Rancher UI/API connectivity"
   default     = null
+  type        = string
 }
 
 variable "tls_key_path" {
   description = "TLS key to use for Rancher UI/API connectivity"
   default     = null
+  type        = string
 }
 
 variable "tls_source" {
   description = "Value for ingress.tls.source when installing the Rancher helm chart"
   default     = "rancher"
+  type        = string
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.6.1"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.4.1"
+    }
+  }
+}


### PR DESCRIPTION
Tested with:
- Private CA/cert
- The default rancher self-signed cert
- Additional helm values.
- Using the default kubeconfig location (~/.kube/config)

Example:
```terraform
module "install_rancher" {
  source = "github.com/dkeightley/terraform-rancher-install?ref=initial"

  rancher_hostname = "example.com"
  rancher_replicas = 1
  rancher_additional_helm_values = [
    "auditLog.level: 1"
  ]
  tls_source = "secret"
  cacerts_path = "certs/ca.pem"
  tls_crt_path = "certs/cert.pem"
  tls_key_path = "certs/key.pem"
}
```